### PR TITLE
Set box sizing to border-box

### DIFF
--- a/assets/stylesheets/environment/generic/_box-sizing.scss
+++ b/assets/stylesheets/environment/generic/_box-sizing.scss
@@ -1,0 +1,11 @@
+html {
+  box-sizing: border-box;
+}
+
+* {
+  &,
+  &:before,
+  &:after {
+    box-sizing: inherit;
+  }
+}

--- a/assets/stylesheets/environment/tools/_placeholders.scss
+++ b/assets/stylesheets/environment/tools/_placeholders.scss
@@ -1,7 +1,7 @@
 %clearfix {
   &:after {
+    clear: both;
     content: "";
     display: block;
-    clear: both;
   }
 }

--- a/gulp/tasks/css.js
+++ b/gulp/tasks/css.js
@@ -20,7 +20,7 @@ gulp.task('css', () => {
       outputStyle: isProduction ? 'compressed' : 'expanded',
     }).on('error', sass.logError))
     .pipe(autoprefixer({
-      browsers: ['> 1%', 'last 2 versions', 'IE 9'],
+      browsers: ['> 0%', 'IE 8'],
     }))
     .pipe(gulpif(!isProduction, sourcemaps.write('.')))
     .pipe(gulp.dest(`${paths.outputStyles}`));


### PR DESCRIPTION
Two specific things for discussion:

To get rid of lint formatting warnings, this code:
```
*, *:before, *:after {
  box-sizing: inherit;
}
```
would need to look something like this:
```
* {
  &,
  &:before,
  &:after {
    box-sizing: inherit;
  }
}
```
...this seems less grokable to me.

Second, for the time being I'm gaming Autoprefixr like this:
```
browsers: ['> 0%', 'IE 8']
```
...meaning we're outputting vendor prefixes no matter what. Once we've made a formal support decision we can look at the use of Autoprefixr (or not) and the settings we need.

Thoughts?