### PR TITLE
Add initial grid support

### DIFF
--- a/assets/stylesheets/components/_callout.scss
+++ b/assets/stylesheets/components/_callout.scss
@@ -9,7 +9,7 @@
 }
 
   .callout--inner {
-    @extend %content-block;
+    @extend %site-width-container;
   }
 
 .callout__111 {

--- a/assets/stylesheets/components/_global-footer.scss
+++ b/assets/stylesheets/components/_global-footer.scss
@@ -4,6 +4,6 @@
 }
 
   .global-footer--inner {
-    @extend %content-block;
+    @extend %site-width-container;
     padding: ($baseline-grid-unit * 6) 0 ($baseline-grid-unit * 12);
   }

--- a/assets/stylesheets/components/_global-header.scss
+++ b/assets/stylesheets/components/_global-header.scss
@@ -3,7 +3,7 @@
 }
 
 .global-header--inner {
-  @extend %content-block;
+  @extend %site-width-container;
   padding: ($baseline-grid-unit * 6) 0;
 }
 

--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -4,7 +4,7 @@
 }
 
 .local-header--inner {
-  @extend %content-block;
+  @extend %site-width-container;
 }
 
 .local-header--title {

--- a/assets/stylesheets/components/_skiplinks.scss
+++ b/assets/stylesheets/components/_skiplinks.scss
@@ -3,7 +3,7 @@
 }
 
   .skiplinks--inner {
-    @extend %content-block;
+    @extend %site-width-container;
   }
 
   .skiplinks--link {

--- a/assets/stylesheets/environment/settings/_grid-layout.scss
+++ b/assets/stylesheets/environment/settings/_grid-layout.scss
@@ -1,0 +1,2 @@
+$site-width: 960px;
+$gutter: $baseline-grid-unit * 8;

--- a/assets/stylesheets/environment/tools/mixins/_conditionals.scss
+++ b/assets/stylesheets/environment/tools/mixins/_conditionals.scss
@@ -4,8 +4,11 @@
 /// for different screen sizes. Based on a mobile
 /// first approach.
 ///
-/// @prop {string} size - can be a set string of tablet|desktop
-/// or a pixel value to change content at
+/// @prop {string} size - a set string of tablet|desktop|mobile which set to a
+/// predefined size
+/// @prop {string} max-width - a pixel size to change layout when smaller
+/// @prop {string} min-width - a pixel size to change layout when greater
+/// @prop {boolean} ignore-for-ie - whether to ignore layout for Internet Explorer
 ///
 /// @example scss - change layout of element at tablet size
 ///   div {
@@ -16,7 +19,7 @@
 ///       float: left;
 ///     }
 ///   }
-@mixin media($size: false, $ignore-for-ie: false) {
+@mixin media($size: false, $max-width: false, $min-width: false, $ignore-for-ie: false) {
   @if $is-ie and ($ignore-for-ie == false) {
     @if $size != mobile {
       @if ($ie-version == 6 and $mobile-ie6 == false) or $ie-version > 6 {
@@ -24,16 +27,28 @@
       }
     }
   } @else {
-    @if $size == "desktop" {
-      @media (min-width: 769px) {
+    @if $size == desktop {
+      @media (min-width: 769px){
         @content;
       }
-    } @else if $size == "tablet" {
-      @media (min-width: 641px) {
+    } @else if $size == tablet {
+      @media (min-width: 641px){
+        @content;
+      }
+    } @else if $size == mobile {
+      @media (max-width: 640px){
+        @content;
+      }
+    } @else if $max-width != false {
+      @media (max-width: $max-width){
+        @content;
+      }
+    } @else if $min-width != false {
+      @media (min-width: $min-width){
         @content;
       }
     } @else {
-      @media (min-width: #{$size}) {
+      @media (min-width: $size){
         @content;
       }
     }

--- a/assets/stylesheets/environment/tools/mixins/_grid-layout.scss
+++ b/assets/stylesheets/environment/tools/mixins/_grid-layout.scss
@@ -1,0 +1,41 @@
+/// Grid column
+/// -----------
+/// Creates a cross browser grid column with a standardised gutter between the
+/// columns.
+///
+/// @prop {number} width - a fraction of what width to create column
+/// @prop {string} full-width [tablet] - at what point to break to full width
+/// @prop {string} float [left] - which way to float column (left/right)
+///
+/// @example scss - Column one quarter of container
+///   div {
+///     @include grid-column(1 / 4);
+///   }
+///
+/// @example scss - Column one half of container
+///   div {
+///     @include grid-column(1 / 2);
+///   }
+///
+/// @example scss - Forcing column to be full width at desktop
+///   div {
+///     @include grid-column(1 / 2, $full-width: desktop);
+///   }
+///
+/// @example scss - Float column to the right
+///   div {
+///     @include grid-column(1 / 2, $float: right);
+///   }
+@mixin grid-column($width, $full-width: tablet, $float: left) {
+  @include box-sizing(border-box);
+  padding: 0 ($gutter / 2);
+
+  @include media($full-width) {
+    float: $float;
+    width: percentage($width);
+  }
+
+  @include ie-lte(7) {
+    width: (($site-width + $gutter) * $width) - $gutter;
+  }
+}

--- a/assets/stylesheets/environment/tools/placeholders/_grid-layout.scss
+++ b/assets/stylesheets/environment/tools/placeholders/_grid-layout.scss
@@ -1,0 +1,61 @@
+/// Site width container
+/// --------------------
+/// An extendable selector to wrap your entire site content block. It limits
+/// sites width to the value defined in settings/_grid-layout.scss and maintains
+/// consistent margins.
+///
+/// @example scss - Site width of #container
+///   #container {
+///     @extend %site-width-container;
+///   }
+%site-width-container {
+  margin: 0 ($gutter / 2);
+  max-width: $site-width;
+
+  @include ie-lte(8) {
+    width: $site-width;
+  }
+
+
+  @include media(tablet) {
+    margin: 0 $gutter;
+  }
+
+  @include media($min-width: ($site-width + $gutter * 2)) {
+    margin: 0 auto;
+  }
+}
+
+/// Outdent
+/// -------
+/// An extendable selector to outdent to the full page-width.
+/// So that you can create elements that take up the gutters on the side of the
+/// page and butt up to the edge of the browser on smaller screens (rather than
+/// leaving a gutter at the edge of the page).
+///
+/// @example scss - Site width of #container
+///   .hero-image-container {
+///     @extend %outdent-to-full-width;
+///   }
+%outdent-to-full-width {
+  margin-left: -($gutter / 2);
+  margin-right: -($gutter / 2);
+
+  @include media(tablet) {
+    margin-left: -$gutter;
+    margin-right: -$gutter;
+  }
+}
+
+/// Outdent
+/// -------
+/// An extendable selector to define a row for grid columns to sit in
+///
+/// @example scss - Site width of #container
+///   .row {
+///     @extend %grid-row;
+///   }
+%grid-row {
+  @extend %clearfix;
+  margin: 0 (-($gutter / 2));
+}

--- a/assets/stylesheets/environment/tools/placeholders/_shims.scss
+++ b/assets/stylesheets/environment/tools/placeholders/_shims.scss
@@ -1,15 +1,13 @@
 %clearfix {
+  @include ie-lte(7) {
+    zoom: 1;
+  }
+
   &:after {
     clear: both;
     content: "";
     display: block;
   }
-}
-
-// Block for a layout "row" - i.e. header, content, footer
-%content-block {
-  margin: 0 auto;
-  max-width: 960px;
 }
 
 %visuallyhidden {

--- a/assets/stylesheets/nhsuk-print.scss
+++ b/assets/stylesheets/nhsuk-print.scss
@@ -9,7 +9,7 @@ $is-print: true;
 @import "environment/tools/mixins/colour";
 @import "environment/tools/mixins/conditionals";
 @import "environment/tools/mixins/typography";
-@import "environment/tools/placeholders";
+@import "environment/tools/placeholders/shims";
 
 @import "environment/generic/reset";
 @import "normalize.css/normalize";

--- a/assets/stylesheets/nhsuk.scss
+++ b/assets/stylesheets/nhsuk.scss
@@ -2,11 +2,14 @@
 @import "environment/settings/colours";
 @import "environment/settings/fonts";
 @import "environment/settings/typography";
+@import "environment/settings/grid-layout";
 
 @import "environment/tools/mixins/colour";
 @import "environment/tools/mixins/conditionals";
+@import "environment/tools/mixins/grid-layout";
 @import "environment/tools/mixins/typography";
-@import "environment/tools/placeholders";
+@import "environment/tools/placeholders/grid-layout";
+@import "environment/tools/placeholders/shims";
 @import "environment/tools/utilities";
 
 @import "environment/generic/box-sizing";

--- a/assets/stylesheets/objects/_main-content.scss
+++ b/assets/stylesheets/objects/_main-content.scss
@@ -1,3 +1,3 @@
 .main-content {
-  @extend %content-block;
+  @extend %site-width-container;
 }


### PR DESCRIPTION
Add initial settings, helpers and mixins for creating basic grid based layouts. 

Includes:
* settings for max width and gutter
* helpers for indented site width containers, grid rows and full width containers
* mixin for creating grid columns