### PR TITLE
Signal if azure environment to SSL redirect

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -7,4 +7,5 @@ module.exports = {
   googleAnalyticsId: process.env.GOOGLE_ANALYTICS_TRACKING_ID,
   staticCdn: process.env.STATIC_CDN || '/',
   dyno: process.env.DYNO,
+  azureWebsiteName: process.env.APPSETTING_WEBSITE_SITE_NAME,
 };

--- a/config/express.js
+++ b/config/express.js
@@ -60,6 +60,7 @@ module.exports = (app, config) => {
     // eslint-disable-next-line new-cap
     app.use(enforce.HTTPS({
       trustProtoHeader: typeof config.dyno !== undefined,
+      trustAzureHeader: typeof config.azureWebsiteName !== undefined,
     }));
   }
 


### PR DESCRIPTION
Azure has a different way of signalling if encrypted connections so we need to check for an Azure specific environment variable in order to turn this one when the app is being served by Azure.