### PR TITLE
Remove OGL license

### DIFF
--- a/app/views/_includes/global/footer.nunjucks
+++ b/app/views/_includes/global/footer.nunjucks
@@ -13,11 +13,5 @@
       </ul>
     </div>
 
-    <p>
-      &copy; Crown copyright<br>
-      Content is available under the <a rel="external" href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">
-      Open Government Licence v3.0</a> except where otherwise stated
-    </p>
-
   </div>
 </div>


### PR DESCRIPTION
Whilst there is uncertainty around the content license we need to
remove the OGL license statement