### PR TITLE
Left align lists, also add a dram of space to ol > li

### DIFF
--- a/assets/stylesheets/units/_lists.scss
+++ b/assets/stylesheets/units/_lists.scss
@@ -1,13 +1,17 @@
 ul {
   @include core-font(20);
   list-style: disc outside;
-  padding-left: 1.5em;
+  padding-left: 1em;
 }
 
 ol {
   @include core-font(20);
   list-style: decimal outside;
-  padding-left: 1.5em;
+  padding-left: 1em;
+
+  li {
+    padding-left: .2em;
+  }
 }
 
 dl {
@@ -16,6 +20,6 @@ dl {
 
 .main-content {
   li {
-    margin-top: 0;
+    margin: ($baseline-grid-unit * 2) 0;
   }
 }


### PR DESCRIPTION
Before:

<img width="677" alt="screen shot 2016-06-21 at 14 57 31" src="https://cloud.githubusercontent.com/assets/1913757/16235152/bd949d66-37cb-11e6-95d2-b8e4db0b11e9.png">

After:

<img width="684" alt="screen shot 2016-06-21 at 14 57 59" src="https://cloud.githubusercontent.com/assets/1913757/16236081/eec746a6-37ce-11e6-9298-bec4532cbd79.png">

Before:

<img width="329" alt="screen shot 2016-06-21 at 14 57 35" src="https://cloud.githubusercontent.com/assets/1913757/16236094/fa298b8a-37ce-11e6-965c-6a8f5b26a43b.png">

After:

<img width="331" alt="screen shot 2016-06-21 at 14 58 04" src="https://cloud.githubusercontent.com/assets/1913757/16236107/02537794-37cf-11e6-9ade-b8173400caee.png">

Also see the `/elements` page:

<img width="324" alt="screen shot 2016-06-21 at 16 11 18" src="https://cloud.githubusercontent.com/assets/1913757/16236114/0e857c4c-37cf-11e6-9638-8f114fc64690.png">
