### PR TITLE
Reduce weight of <abbr> underline

### DIFF
--- a/assets/stylesheets/nhsuk.scss
+++ b/assets/stylesheets/nhsuk.scss
@@ -27,6 +27,7 @@
 @import "units/paragraphs";
 @import "units/tables";
 @import "units/quotes";
+@import "units/inline";
 
 // objects (eg. grid)
 @import "objects/grid";

--- a/assets/stylesheets/units/_inline.scss
+++ b/assets/stylesheets/units/_inline.scss
@@ -1,0 +1,5 @@
+abbr[title] {
+  border-bottom-style: dotted;
+  border-bottom-width: 1px;
+  text-decoration: none;
+}


### PR DESCRIPTION
Before:
<img width="272" alt="screen shot 2016-06-21 at 17 26 11" src="https://cloud.githubusercontent.com/assets/1913757/16237734/aa5244a6-37d5-11e6-8492-1f045ab11726.png">


After:
<img width="265" alt="screen shot 2016-06-21 at 17 26 34" src="https://cloud.githubusercontent.com/assets/1913757/16237737/ad19434c-37d5-11e6-96ab-14e6572ca676.png">

