### PR TITLE
Use full url for Heroku multi buildpacks

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,7 +16,7 @@
   ],
   "buildpacks": [
     {
-      "url": "heroku/heroku-buildpack-multi"
+      "url": "https://github.com/heroku/heroku-buildpack-multi.git"
     }
   ]
 }


### PR DESCRIPTION
Heroku doesn't support shorthand for multi buildpacks buildpack
references