### PR TITLE
Update mocha setup

### DIFF
--- a/test/unit/.eslintrc
+++ b/test/unit/.eslintrc
@@ -5,7 +5,9 @@
   "globals": {
     "appFolder": true,
     "rootFolder": true,
-    "should": true
+    "should": true,
+    "sinon": true,
+    "proxyquire": true
   },
   "rules": {
     "no-unused-expressions": 0

--- a/test/unit/common.js
+++ b/test/unit/common.js
@@ -1,13 +1,16 @@
 const chai = require('chai').use(require('sinon-chai')).use(require('chai-as-promised'));
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+
+require('sinomocha')();
 
 // set mocha globals
 global.chai = chai;
 global.should = chai.should();
-global.sinon = require('sinon');
+global.sinon = sinon;
+global.proxyquire = proxyquire;
 global.appFolder = `${process.cwd()}/app`;
 global.rootFolder = `${process.cwd()}`;
-
-require('sinomocha')();
 
 process.setMaxListeners(0);
 process.stdout.setMaxListeners(0);

--- a/test/unit/controllers/healthcheck.test.js
+++ b/test/unit/controllers/healthcheck.test.js
@@ -1,21 +1,12 @@
-const proxyquire = require('proxyquire');
-const sinon = require('sinon');
-
-const packageMock = {
-  version: undefined,
-};
-const gitLookupMock = {
-  getGitSha: sinon.stub(),
-};
-
 describe('Healthcheck controller', () => {
-  let controller;
-
   beforeEach(() => {
-    controller = proxyquire(`${appFolder}/controllers/healthcheck`, {
-      '../../package.json': packageMock,
-      '../../lib/git-lookup': gitLookupMock,
-    });
+    this.sandbox = sinon.sandbox.create();
+    this.getGitSha = this.sandbox.stub();
+    this.version = undefined;
+  });
+
+  afterEach(() => {
+    this.sandbox.restore();
   });
 
   describe('#index', () => {
@@ -30,46 +21,51 @@ describe('Healthcheck controller', () => {
           done();
         },
       };
+      const controller = proxyquire(`${appFolder}/controllers/healthcheck`, {
+        '../../package.json': {
+          version: this.version,
+        },
+        '../../lib/git-lookup': {
+          getGitSha: this.getGitSha,
+        },
+      });
 
       controller.index({}, res);
     });
-  });
 
-  describe('#index', () => {
-    const version = 1;
-
-    before(() => {
-      packageMock.version = version;
-    });
-
-    it('should return a version if set', (done) => {
+    it('should return the correct package version', (done) => {
+      const pkgVersion = '1';
       const res = {
         json: (params) => {
-          params.version.should.equal(version);
+          params.version.should.equal(pkgVersion);
           done();
         },
       };
+      const controller = proxyquire(`${appFolder}/controllers/healthcheck`, {
+        '../../package.json': {
+          version: pkgVersion,
+        },
+        '../../lib/git-lookup': {
+          getGitSha: this.getGitSha,
+        },
+      });
 
       controller.index({}, res);
     });
-  });
 
-  describe('#index', () => {
-    const sha = 'gitsha';
-
-    before(() => {
-      gitLookupMock.getGitSha = sinon.stub().returns(sha);
-    });
-
-    it('should return a git sha if one is set', (done) => {
+    it('should return the correct git sha', (done) => {
+      const sha = 'gitsha';
       const res = {
         json: (params) => {
           params.sha.should.equal(sha);
-          gitLookupMock.getGitSha().should.equal(sha);
-          gitLookupMock.getGitSha.should.have.been.called;
           done();
         },
       };
+      const controller = proxyquire(`${appFolder}/controllers/healthcheck`, {
+        '../../lib/git-lookup': {
+          getGitSha: this.getGitSha.returns(sha),
+        },
+      });
 
       controller.index({}, res);
     });


### PR DESCRIPTION
This updates how unit tests run. It adds sinon and proxyquire to the mocha
globals.

It also makes better use of sinon's sandboxes to clean up after itself.