### PR TITLE
Amend CSP policy to allow images from GA

### DIFF
--- a/config/express.js
+++ b/config/express.js
@@ -60,6 +60,10 @@ module.exports = (app, config) => {
           'data:',
           'www.google-analytics.com',
         ],
+        imgSrc: [
+          '\'self\'',
+          'www.google-analytics.com',
+        ],
         fontSrc: [
           (config.staticCdn ? config.staticCdn.replace('//', '') : null),
         ],


### PR DESCRIPTION
Allows the app to load images from google-analytics.com domain which
are used for tracking