### PR TITLE
Set link back to equivalent NHS Choices pages

### DIFF
--- a/app/controllers/stomach-ache.js
+++ b/app/controllers/stomach-ache.js
@@ -3,6 +3,7 @@ function index(req, res) {
     title: 'Stomach ache',
     intro: 'Most stomach aches aren’t anything serious and will go away after a few days.',
     feedback: true,
+    choicesOrigin: 'conditions/stomach-ache-abdominal-pain/Pages/Introduction.aspx',
     emergencyCallout: true,
     nonEmergencyCallout: true,
     gpCallout: true,

--- a/app/views/_includes/new-site-message.nunjucks
+++ b/app/views/_includes/new-site-message.nunjucks
@@ -6,6 +6,6 @@
     {% else %}
       Go
     {% endif %}
-    <a href="http://www.nhs.uk/">back to NHS Choices.</a>
+    <a href="http://www.nhs.uk/{{ choicesOrigin }}">back to NHS Choices.</a>
   </p>
 </div>

--- a/test/unit/controllers/stomach-ache.test.js
+++ b/test/unit/controllers/stomach-ache.test.js
@@ -10,6 +10,12 @@ describe('Stomach ache controller', () => {
           params.should.have.property('emergencyCallout');
           params.should.have.property('nonEmergencyCallout');
           params.should.have.property('gpCallout');
+
+          params.should.have.property('feedback');
+          params.feedback.should.equal(true);
+
+          params.should.have.property('choicesOrigin');
+          params.choicesOrigin.should.not.be.empty;
           done();
         },
       };


### PR DESCRIPTION
Allow current content pages to go back to a specific destination on NHS Choices