### PR TITLE
Tweak grid

### DIFF
--- a/app/views/_includes/local-header.nunjucks
+++ b/app/views/_includes/local-header.nunjucks
@@ -2,7 +2,9 @@
   <div class="local-header--inner">
     <h1 class="local-header--title">{{ title }}</h1>
     {% if intro %}
-      <p class="local-header--intro">{{ intro }}</p>
+      <div class="local-header--intro">
+        <p>{{ intro }}</p>
+      </div>
     {% endif %}
   </div>
 </div>

--- a/app/views/_layouts/content-page.nunjucks
+++ b/app/views/_layouts/content-page.nunjucks
@@ -9,30 +9,34 @@
       <div class="grid-row">
 
         <div class="column__two-thirds">
-          <section>
-            {% block main_content %}{% endblock %}
-          </section>
-
-          {% if gpCallout %}
-            <section class="callout callout__info">
-              <h2>See your GP if</h2>
-
-              {% block gp_callout %}{% endblock %}
+          <div class="reading-width">
+            <section>
+              {% block main_content %}{% endblock %}
             </section>
-          {% endif %}
-        </div>
 
-        <div class="column__one-third column__right">
-          {% block aside_content %}
-            {% if emergencyCallout %}
-              <section class="callout callout__alert callout__overlap">
-                <h2>Call 999 or go to <abbr title="Accident and Emergency">
-                  A&amp;E</abbr> if you</h2>
+            {% if gpCallout %}
+              <section class="callout callout__info">
+                <h2>See your GP if</h2>
 
-                {% block aside_callout %}{% endblock %}
+                {% block gp_callout %}{% endblock %}
               </section>
             {% endif %}
-          {% endblock %}
+          </div>
+        </div>
+
+        <div class="column__one-third-right">
+          <div class="reading-width">
+            {% block aside_content %}
+              {% if emergencyCallout %}
+                <section class="callout callout__alert callout__overlap">
+                  <h2>Call 999 or go to <abbr title="Accident and Emergency">
+                    A&amp;E</abbr> if you</h2>
+
+                  {% block aside_callout %}{% endblock %}
+                </section>
+              {% endif %}
+            {% endblock %}
+          </div>
         </div>
 
       </div>

--- a/assets/stylesheets/components/_callout.scss
+++ b/assets/stylesheets/components/_callout.scss
@@ -28,7 +28,7 @@
 }
 
 .callout__overlap {
-  @include media(tablet) {
+  @include media(desktop) {
     @include background-clip(padding-box);
     position: relative;
     top: -($baseline-grid-unit * 16);

--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -27,8 +27,5 @@
   .local-header--intro {
     color: $white;
     margin-top: $baseline-grid-unit * 4;
-
-    @include media(tablet) {
-      width: percentage(2 / 3);
-    }
+    max-width: $measure;
   }

--- a/assets/stylesheets/environment/settings/_typography.scss
+++ b/assets/stylesheets/environment/settings/_typography.scss
@@ -6,6 +6,7 @@ $is-print: false !default;
 $base-font-size: 16px;
 $baseline-grid-unit: 4px;
 $default-spacing-unit: $baseline-grid-unit * 4;
+$measure: 40em; // comfy reading width of ~ 55-65 characters
 
 $type-settings-map: (
   16: -1,

--- a/assets/stylesheets/environment/tools/mixins/_conditionals.scss
+++ b/assets/stylesheets/environment/tools/mixins/_conditionals.scss
@@ -28,7 +28,7 @@
     }
   } @else {
     @if $size == desktop {
-      @media (min-width: 769px){
+      @media (min-width: 925px){
         @content;
       }
     } @else if $size == tablet {

--- a/assets/stylesheets/environment/tools/mixins/_grid-layout.scss
+++ b/assets/stylesheets/environment/tools/mixins/_grid-layout.scss
@@ -26,7 +26,8 @@
 ///   div {
 ///     @include grid-column(1 / 2, $float: right);
 ///   }
-@mixin grid-column($width, $full-width: tablet, $float: left) {
+@mixin grid-column($width, $full-width: desktop, $float: left) {
+  display: block;
   padding: 0 ($gutter / 2);
 
   @include media($full-width) {

--- a/assets/stylesheets/environment/tools/placeholders/_layout.scss
+++ b/assets/stylesheets/environment/tools/placeholders/_layout.scss
@@ -17,7 +17,7 @@
   }
 
 
-  @include media(tablet) {
+  @include media(desktop) {
     margin: 0 $gutter;
   }
 
@@ -41,7 +41,7 @@
   margin-left: -($gutter / 2);
   margin-right: -($gutter / 2);
 
-  @include media(tablet) {
+  @include media(desktop) {
     margin-left: -$gutter;
     margin-right: -$gutter;
   }
@@ -59,11 +59,24 @@
   @extend %clearfix;
   margin: 0 (-($gutter / 2));
 
-  @include media(tablet) {
+  @include media(desktop) {
     .page-section & {
       > * {
         margin-top: 0;
       }
     }
   }
+}
+
+/// Measure
+/// -------
+/// Set a max width of $measure for a comfortable reading width
+///
+/// @example scss - Width of .article
+///   .article {
+///     @extend %measure;
+///   }
+%measure,
+.reading-width {
+  max-width: $measure;
 }

--- a/assets/stylesheets/nhsuk.scss
+++ b/assets/stylesheets/nhsuk.scss
@@ -10,7 +10,7 @@
 @import "environment/tools/mixins/device-pixels";
 @import "environment/tools/mixins/grid-layout";
 @import "environment/tools/mixins/typography";
-@import "environment/tools/placeholders/grid-layout";
+@import "environment/tools/placeholders/layout";
 @import "environment/tools/placeholders/shims";
 @import "environment/tools/utilities";
 

--- a/assets/stylesheets/objects/_grid.scss
+++ b/assets/stylesheets/objects/_grid.scss
@@ -19,25 +19,44 @@
 }
 
 // Use .grid-column to create a grid column with 15px gutter
-// By default grid columns break to become full width at tablet size
+// By default grid columns break to become full width at 925px
 .column__one-quarter {
   @include grid-column(1 / 4);
-}
-
-.column__one-half {
-  @include grid-column(1 / 2);
 }
 
 .column__one-third {
   @include grid-column(1 / 3);
 }
 
+.column__one-half {
+  @include grid-column(1 / 2);
+}
+
 .column__two-thirds {
   @include grid-column(2 / 3);
 }
 
-.column__right {
-  @include media(tablet) {
-    float: right;
-  }
+.column__three-quarters {
+  @include grid-column(3 / 4);
+}
+
+// Right floating column classes
+.column__one-quarter-right {
+  @include grid-column(1 / 4, $float: right);
+}
+
+.column__one-third-right {
+  @include grid-column(1 / 3, $float: right);
+}
+
+.column__one-half-right {
+  @include grid-column(1 / 2, $float: right);
+}
+
+.column__two-thirds-right {
+  @include grid-column(2 / 3, $float: right);
+}
+
+.column__three-quarters-right {
+  @include grid-column(3 / 4, $float: right);
 }


### PR DESCRIPTION
Tweaks to the grid, based on the fact that "tablet" as a breakpoint for this particular design isn't great. See grab:

![641](https://cloud.githubusercontent.com/assets/1913757/16450079/e820325c-3df2-11e6-9a92-4066772f36c7.png)

To fix this, the "desktop" has been redefined at 925px, based on looking at the content we have in nhs-design.herokuapp.com - this is the start of a more content-out approach, rather than predefining "mobile", "tablet", "desktop". While these are useful to have as large general queries, we're going to want to be more component led than this.

Also added `$measure: 40em;` for comfortable reading width. This is used as a `reading-width` class when marking up grids.