### PR TITLE
Improve performance of linting

### DIFF
--- a/gulp/tasks/lint.js
+++ b/gulp/tasks/lint.js
@@ -11,7 +11,10 @@ gulp.task('lint-css', () => {
 
 gulp.task('lint-js', () => {
   return gulp.src([
-    '**/*.js',
+    `${paths.sourceJS}/**/*.js`,
+    `${paths.sourceApp}/**/*.js`,
+    `${paths.projectDir}/+(config|gulp|lib|public|test)/**/*.js`,
+    `${paths.projectDir}/*.js`,
   ])
   .pipe(eslint())
   .pipe(eslint.format())


### PR DESCRIPTION
Rather than specifying all JS files from the root for the JS linter,
give it only the folders we're concerned with to improve performance.

This means it doesn't have to trawl every single folder in the application,
including ignored folders.