### PR TITLE
Tweak local header border colour

### DIFF
--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -1,6 +1,6 @@
 .local-header {
   background-color: $nhs-blue;
-  border-top: 1px solid tint($nhs-blue, 80%);
+  border-top: 1px solid tint($nhs-blue, 20%);
 }
 
   .local-header--inner {


### PR DESCRIPTION
20% white tint, not 80%

*Before:* 
<img width="270" alt="screen shot 2016-06-29 at 12 37 21" src="https://cloud.githubusercontent.com/assets/1913757/16450680/3f1bcc76-3df6-11e6-9ce2-cab6ffb52ead.png">

*After:*
<img width="284" alt="screen shot 2016-06-29 at 12 37 16" src="https://cloud.githubusercontent.com/assets/1913757/16450684/489bdc00-3df6-11e6-8dda-6505c8b51317.png">


