### PR TITLE
Add CSRF protection

### DIFF
--- a/app/middleware/csrf-token.js
+++ b/app/middleware/csrf-token.js
@@ -1,0 +1,8 @@
+module.exports = () => {
+  return function csrfToken(req, res, next) {
+    /* eslint-disable no-param-reassign */
+    res.locals.csrfToken = req.csrfToken();
+    /* eslint-enable no-param-reassign */
+    next();
+  };
+};

--- a/app/views/_includes/feedback-form.nunjucks
+++ b/app/views/_includes/feedback-form.nunjucks
@@ -36,7 +36,8 @@
         <button type="submit" class="button">Send feedback</button>
         <button type="reset" class="button button__cancel">Cancel</button>
 
-        <input name="feedback-form-path" type="hidden" value="{{ FEEDBACKFORM.path }}">
+        <input type="hidden" name="feedback-form-path" value="{{ FEEDBACKFORM.path }}">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
       </form>
     {% endif %}
 

--- a/config/express.js
+++ b/config/express.js
@@ -8,12 +8,14 @@ const nunjucks = require('nunjucks');
 const enforce = require('express-sslify');
 const churchill = require('churchill');
 const validator = require('express-validator');
+const csrf = require('csurf');
 
 const logger = require('../lib/logger');
 const checkSecure = require('../app/middleware/check-secure');
 const locals = require('../app/middleware/locals');
 const assetPath = require('../app/middleware/asset-path');
 const feedback = require('../app/middleware/feedback');
+const csrfToken = require('../app/middleware/csrf-token');
 const router = require('./routes');
 
 module.exports = (app, config) => {
@@ -28,18 +30,28 @@ module.exports = (app, config) => {
     app.use(churchill(logger));
   }
 
+  app.use(locals(config));
+
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({
     extended: true,
   }));
   app.use(cookieParser());
   app.use(validator());
-  app.use(compress());
-  app.use(methodOverride());
   app.use(checkSecure({
     trustProtoHeader: config.trustProtoHeader,
     trustAzureHeader: config.trustAzureHeader,
   }));
+  app.use(assetPath(config));
+  app.use(feedback());
+
+  app.use(csrf({
+    cookie: true,
+  }));
+  app.use(csrfToken());
+
+  app.use(compress());
+  app.use(methodOverride());
 
   app.use(express.static(`${config.root}/public`));
   if (config.env !== 'production') {
@@ -90,11 +102,6 @@ module.exports = (app, config) => {
     }));
   }
 
-  // custom middlewares
-  app.use(locals(config));
-  app.use(assetPath(config));
-  app.use(feedback());
-
   // router
   app.use('/', router);
 
@@ -106,6 +113,11 @@ module.exports = (app, config) => {
 
   // eslint-disable-next-line no-unused-vars
   app.use((err, req, res, next) => {
+    if (err.code === 'EBADCSRFTOKEN') {
+      // eslint-disable-next-line no-param-reassign
+      err.message = 'Invalid form token';
+    }
+
     res.status(err.status || 500);
     res.render('error', {
       message: err.message,

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "churchill": "0.0.5",
     "compression": "^1.5.2",
     "cookie-parser": "^1.3.3",
+    "csurf": "^1.9.0",
     "del": "^2.2.0",
     "eslint": "^2.10.2",
     "eslint-config-airbnb-base": "^3.0.1",


### PR DESCRIPTION
Uses the csurf express library to add csrf protection using middleware.

Some middlewares were re-ordered to allow error page to be displayed correctly
when the csrf middleware throws an error.