### PR TITLE
Disable ARRAffinity cookie

### DIFF
--- a/app/middleware/affinity-cookie.js
+++ b/app/middleware/affinity-cookie.js
@@ -1,0 +1,6 @@
+module.exports = () => {
+  return function affinityCookie(req, res, next) {
+    res.header('Arr-Disable-Session-Affinity', 'True');
+    next();
+  };
+};

--- a/config/express.js
+++ b/config/express.js
@@ -16,6 +16,7 @@ const locals = require('../app/middleware/locals');
 const assetPath = require('../app/middleware/asset-path');
 const feedback = require('../app/middleware/feedback');
 const csrfToken = require('../app/middleware/csrf-token');
+const affinityCookie = require('../app/middleware/affinity-cookie');
 const router = require('./routes');
 
 module.exports = (app, config) => {
@@ -100,6 +101,10 @@ module.exports = (app, config) => {
       trustProtoHeader: config.trustProtoHeader,
       trustAzureHeader: config.trustAzureHeader,
     }));
+
+    if (config.trustAzureHeader) {
+      app.use(affinityCookie());
+    }
   }
 
   // router


### PR DESCRIPTION
Azure sets a cookie to keep users connected to a particular instance. This is
something we're not using right now so are disabling that cookie.

See https://azure.microsoft.com/en-gb/blog/disabling-arrs-instance-affinity-in-windows-azure-web-sites/