### PR TITLE
Add acceptance tests for basic feedback mechanism

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "sinon-chai": "^2.8.0",
     "ua-parser-js": "^0.7.10",
     "wdio-mocha-framework": "^0.3.1",
-    "webdriverio": "^4.0.9"
+    "webdriverio": "^4.1.1"
   },
   "pre-commit": [
     "test:unit",

--- a/test/acceptance/pageobjects/content-page.page.js
+++ b/test/acceptance/pageobjects/content-page.page.js
@@ -19,7 +19,7 @@ const formPage = Object.create(page, {
    * define or overwrite page methods
    */
   open: {
-    value: () => {
+    value: function open() {
       page.open.call(this, 'symptoms/stomach-ache');
     },
   },

--- a/test/acceptance/pageobjects/feedback.page.js
+++ b/test/acceptance/pageobjects/feedback.page.js
@@ -1,0 +1,59 @@
+const page = require('./page');
+
+const feedbackPage = Object.create(page, {
+  /**
+   * define elements
+   */
+  banner: {
+    get: () => {
+      return browser.element('.js-feedback-banner');
+    },
+  },
+  toggle: {
+    get: () => {
+      return browser.element('.js-feedback-toggle');
+    },
+  },
+  feedbackContainer: {
+    get: () => {
+      return browser.element('#page-feedback');
+    },
+  },
+  form: {
+    get: () => {
+      return browser.element('form[name="feedback-form"]');
+    },
+  },
+  cancelBtn: {
+    get: () => {
+      return browser.element('#page-feedback button[type="reset"]');
+    },
+  },
+  comment: {
+    get: () => {
+      return browser.element('#feedback-form-comments');
+    },
+  },
+  errorSummary: {
+    get: () => {
+      return browser.element('#page-feedback .callout__error');
+    },
+  },
+
+
+  /**
+   * define or overwrite page methods
+   */
+  open: {
+    value: function open() {
+      page.open.call(this, 'symptoms/stomach-ache');
+    },
+  },
+  submit: {
+    value: function value() {
+      this.form.submitForm();
+    },
+  },
+});
+
+module.exports = feedbackPage;

--- a/test/acceptance/pageobjects/page.js
+++ b/test/acceptance/pageobjects/page.js
@@ -1,6 +1,6 @@
 function Page() {}
 
-Page.prototype.open = (path) => {
+Page.prototype.open = (path = '') => {
   browser.url(`/${path}`);
 };
 

--- a/test/acceptance/specs/feedback.js
+++ b/test/acceptance/specs/feedback.js
@@ -1,0 +1,49 @@
+const Page = require('../pageobjects/page');
+const FeedbackPage = require('../pageobjects/feedback.page');
+
+describe('feedback mechanism', () => {
+  describe('when not on a content page', () => {
+    it('should not be present', () => {
+      Page.open();
+      FeedbackPage.banner.isVisible().should.be.true;
+      FeedbackPage.banner.getText().should.not.contain('Tell us what you think');
+      FeedbackPage.feedbackContainer.isExisting().should.be.false;
+    });
+  });
+
+  describe('when on a content page with javascript enabled', () => {
+    it('should be present and hidden', () => {
+      FeedbackPage.open();
+      FeedbackPage.banner.isVisible().should.be.true;
+      FeedbackPage.banner.getText().should.contain('Tell us what you think');
+      FeedbackPage.feedbackContainer.isExisting().should.be.true;
+      FeedbackPage.feedbackContainer.isVisible().should.be.false;
+    });
+
+    it('should toggle show/hide', () => {
+      FeedbackPage.open();
+      FeedbackPage.feedbackContainer.isVisible().should.be.false;
+      FeedbackPage.toggle.click();
+      FeedbackPage.feedbackContainer.isVisible().should.be.true;
+      FeedbackPage.cancelBtn.click();
+      FeedbackPage.feedbackContainer.isVisible().should.be.false;
+    });
+
+    it('should return an error if submitted empty', () => {
+      FeedbackPage.open();
+      FeedbackPage.toggle.click();
+      FeedbackPage.submit();
+
+      FeedbackPage.errorSummary.waitForExist();
+      FeedbackPage.errorSummary.isVisible().should.be.true;
+      FeedbackPage.errorSummary.getText().should.contain('feedback area was empty');
+      FeedbackPage.comment.getAttribute('class').should.contain('error');
+    });
+
+    it('should receive a thank you message if submitted with content', () => {
+      // TODO: Submit form to dev API so can be tested fully
+      // FeedbackPage.form.isExisting().should.be.false;
+      // FeedbackPage.feedbackContainer.getText().should.contain('Thank you');
+    });
+  });
+});

--- a/test/acceptance/wdio.cloud.conf.js
+++ b/test/acceptance/wdio.cloud.conf.js
@@ -92,14 +92,14 @@ exports.config = (function headlessConfig(globalConfig) {
   }, {
     browserName: 'iPhone',
     platform: 'MAC',
-    device: 'iPhone 5',
+    device: 'iPhone 6S',
     project,
     build,
     maxInstances,
   }, {
     browserName: 'iPad',
     platform: 'MAC',
-    device: 'iPad 4th',
+    device: 'iPad Air 2',
     project,
     build,
     maxInstances,
@@ -112,7 +112,7 @@ exports.config = (function headlessConfig(globalConfig) {
     maxInstances,
   }];
 
-  globalConfig.onPrepare = globalConfig.onComplete = () => {
+  globalConfig.onPrepare = globalConfig.onComplete = globalConfig.afterTest = () => {
     return;
   };
 

--- a/test/acceptance/wdio.conf.js
+++ b/test/acceptance/wdio.conf.js
@@ -187,6 +187,7 @@ const wdioConfig = {
   // See the full list at http://mochajs.org/
   mochaOpts: {
     ui: 'bdd',
+    timeout: 20000,
   },
   //
   // =====
@@ -261,12 +262,12 @@ const wdioConfig = {
     if (!test.passed) {
       utils.saveErrorshot(test);
     }
-    browser.deleteCookie();
   },
   //
   // Hook that gets executed after the suite has ended
-  // afterSuite: function (suite) {
-  // },
+  afterSuite: () => {
+    browser.deleteCookie();
+  },
   //
   // Gets executed after all tests are done. You still have access to all global variables from
   // the test.


### PR DESCRIPTION
This adds an initial set of journeys for the feedback mechanism.

However, it cannot be currently tested with a successful submission until
a way to setup a dev environment for each instance is added.

#### Questions:

- Are we happy to merge as is and do a separate PR when we have a way to use a dev instance to test successful submissions?
- Are the tests now taking too long? They're currently running at about 12-15mins and this is mainly because of the large amount of capabilities we're running against on Browserstack. Options are that we could reduce the amount of capabilities or leave and be happy with the longer time