### PR TITLE
Don't use native .bind() method to allow for IE8 support

### DIFF
--- a/assets/javascripts/modules/feedback-form.js
+++ b/assets/javascripts/modules/feedback-form.js
@@ -22,8 +22,8 @@ FeedbackForm.prototype.cacheEls = function cacheEls() {
 
 FeedbackForm.prototype.bindEvents = function bindEvents() {
   this.$body
-    .on('click.feedbackForm', this.toggleEl, this.showForm.bind(this))
-    .on('click.feedbackForm', 'button[type="reset"]', this.hideForm.bind(this));
+    .on('click.feedbackForm', this.toggleEl, $.proxy(this.showForm, this))
+    .on('click.feedbackForm', 'button[type="reset"]', $.proxy(this.hideForm, this));
 };
 
 FeedbackForm.prototype.render = function render() {


### PR DESCRIPTION
IE8 doesn't support .bind() for changing the context so switching to jQuery
to bind click handlers