### PR TITLE
Don't add source map reference in webpack production build

### DIFF
--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -5,7 +5,7 @@ const webpackConfig = require('./webpack.config.js');
 module.exports = (function headlessConfig(config) {
   config.plugins.push(new webpack.optimize.UglifyJsPlugin());
 
-  config.devtool = 'source-map';
+  config.devtool = 'hidden-source-map';
 
   return config;
 }(webpackConfig));


### PR DESCRIPTION
Some browsers were throwing a `404` for the `.map` files as they were referenced in the bundle. 

Setting the webpack [devtool](https://webpack.github.io/docs/configuration.html#devtool) config item to `hidden-source-map` removes the reference in the bundles. 